### PR TITLE
unify names around auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,6 +1,7 @@
 # This will be removed when this project has more than one maintainers
 
 name: auto-approve
+
 on:
   pull_request:
     types:
@@ -10,7 +11,7 @@ on:
       - ready_for_review
 
 jobs:
-  auto_approve:
+  approve:
     if: |
       github.event.pull_request.user.login == 'kanarus' &&
       !github.event.pull_request.draft
@@ -19,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: auto-approve
+      - name: approve
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
remove `auto_aprove`

use `auto-approve` for workflow name and `approve` for job name