### PR TITLE
fix: remove wrong terminated log

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run() -> io::Result<()> {
         }
         1 => {
             let status = handles.pop_front().unwrap().wait()?;
-            let code = status.code().unwrap_or({
+            let code = status.code().unwrap_or_else(|| {
                 eprintln!("[cargo-metask] task terminated by signal");
                 1
             });


### PR DESCRIPTION
avoid always-print the log by fixing:

```rust
        1 => {
            let status = handles.pop_front().unwrap().wait()?;
            let code = status.code().unwrap_or({
                eprintln!("[cargo-metask] task terminated by signal");
                1
            });
            exit(code);
        }
```

to

```rust
        1 => {
            let status = handles.pop_front().unwrap().wait()?;
            let code = status.code().unwrap_or_else(|| {
                eprintln!("[cargo-metask] task terminated by signal");
                1
            });
            exit(code);
        }
```